### PR TITLE
Add blinking when 30s left on timer

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -85,7 +85,12 @@ func init() {
 		if emoji == "" {
 			emoji = "🍅"
 		}
-		fmt.Printf("%v %v\n", emoji, endt.Sub(time.Now()).Round(time.Second))
+		timeLeft := endt.Sub(time.Now()).Round(time.Second)
+		if timeLeft < time.Second*30 && timeLeft%(time.Second*2) == 0 {
+			fmt.Printf("%v\n", timeLeft)
+			return nil
+		}
+		fmt.Printf("%v %v\n", emoji, timeLeft)
 		return nil
 	}
 }


### PR DESCRIPTION
Tmux does not support ANSI escape codes. The pomo command is run
on an interval, it would not show up long enough for the ANSI
blinking to take effect. Therefore, I found it better to have the
emoji blinking. When the time left is less than 30s I only show the
emoji on even numbers, creating a blinking effect.